### PR TITLE
Add Japanese translation

### DIFF
--- a/locale/ja/tungsten.cfg
+++ b/locale/ja/tungsten.cfg
@@ -1,0 +1,58 @@
+[entity-name]
+tungsten-ore=Wolframite
+tungsten-chest=Tungsten chest
+advanced-carbon-furnace=__ITEM__advanced-carbon-furnace__
+
+[entity-description]
+advanced-carbon-furnace=For making tungsten carbide quickly and efficiently. Burns a lot of fuel.
+
+
+[autoplace-control-names]
+tungsten-ore=[item=tungsten-ore] Wolframite
+
+[item-name]
+tungsten-ore=Wolframite
+tungsten-dust=Tungsten dust
+tungsten-plate=Tungsten plate
+tungsten-carbide=Tungsten carbide
+rocket-engine-nozzle=Rocket engine nozzle
+enriched-tungsten=Enriched tungsten
+tungsten-chest=Tungsten chest
+compressed-tungsten-ore=Compressed tungsten ore
+advanced-carbon-furnace=Advanced carbon furnace
+
+[item-description]
+tungsten-ore=Can be smelted into tungsten plates
+enriched-tungsten=Can be efficiently smelted into tungsten plates
+advanced-carbon-furnace=For making tungsten carbide quickly and efficiently. Burns a lot of fuel.
+
+[technology-name]
+tungsten-processing=Tungsten processing
+enriched-tungsten=Enriched tungsten
+tungsten-matter-processing=Tungsten conversion
+advanced-carbon-furnace=__ITEM__advanced-carbon-furnace__
+
+[technology-description]
+enriched-tungsten=Enrich tungsten ore, purifying with ammonia [fluid=ammonia] and water [fluid=water], improving the final yield. Produce dirty water [fluid=dirty-water] as a byproduct.
+
+[recipe-name]
+enriched-tungsten=__ITEM__enriched-tungsten__
+tungsten-plate=__ITEM__tungsten-plate__
+smelt-compressed-tungsten-ore=__ITEM__tungsten-plate__
+tungsten-dust=__ITEM__tungsten-dust__
+dirty-water-filtration-tungsten=Filter dirty water [item=tungsten-ore]
+
+[recipe-description]
+enriched-tungsten=Enrich tungsten ore, purifying with ammonia [fluid=ammonia] and water [fluid=water], improving the final yield. Produce dirty water [fluid=dirty-water] as a byproduct.
+
+dirty-water-filtration-tungsten=Filter dirty water, giving wolframite [item=tungsten-ore] and stone [item=stone] (probabilistically).
+
+# Settings
+
+[mod-setting-name]
+bztungsten-avoid-military=Avoid military science pack
+bztungsten-advanced-carbon-furnace=Enable the advanced carbon furnace
+
+[mod-setting-description]
+bztungsten-avoid-military=If 'yes', rocketry will no longer require military science.
+bztungsten-advanced-carbon-furnace=A furnace to smelt tungsten carbide quickly. Meant only for very large factories.

--- a/locale/ja/tungsten.cfg
+++ b/locale/ja/tungsten.cfg
@@ -1,58 +1,58 @@
 [entity-name]
-tungsten-ore=Wolframite
-tungsten-chest=Tungsten chest
+tungsten-ore=狼重石
+tungsten-chest=タングステン製チェスト
 advanced-carbon-furnace=__ITEM__advanced-carbon-furnace__
 
 [entity-description]
-advanced-carbon-furnace=For making tungsten carbide quickly and efficiently. Burns a lot of fuel.
+advanced-carbon-furnace=高速かつ効率的に炭化タングステンを生成できます。燃料を大量に消費します。
 
 
 [autoplace-control-names]
-tungsten-ore=[item=tungsten-ore] Wolframite
+tungsten-ore=[item=tungsten-ore] 狼重石
 
 [item-name]
-tungsten-ore=Wolframite
-tungsten-dust=Tungsten dust
-tungsten-plate=Tungsten plate
-tungsten-carbide=Tungsten carbide
-rocket-engine-nozzle=Rocket engine nozzle
-enriched-tungsten=Enriched tungsten
-tungsten-chest=Tungsten chest
+tungsten-ore=狼重石
+tungsten-dust=狼重石の粉末
+tungsten-plate=タングステン板
+tungsten-carbide=炭化タングステン
+rocket-engine-nozzle=ロケットエンジンノズル
+enriched-tungsten=純化タングステン
+tungsten-chest=タングステン製チェスト
 compressed-tungsten-ore=Compressed tungsten ore
-advanced-carbon-furnace=Advanced carbon furnace
+advanced-carbon-furnace=強化炭素炉
 
 [item-description]
-tungsten-ore=Can be smelted into tungsten plates
-enriched-tungsten=Can be efficiently smelted into tungsten plates
-advanced-carbon-furnace=For making tungsten carbide quickly and efficiently. Burns a lot of fuel.
+tungsten-ore=精錬してタングステン板を得ることができます
+enriched-tungsten=精錬して効率的にタングステン板を得ることができます
+advanced-carbon-furnace=高速かつ効率的に炭化タングステンを生成できます。燃料を大量に消費します。
 
 [technology-name]
-tungsten-processing=Tungsten processing
-enriched-tungsten=Enriched tungsten
-tungsten-matter-processing=Tungsten conversion
+tungsten-processing=タングステン処理
+enriched-tungsten=タングステン純化
+tungsten-matter-processing=タングステン変換
 advanced-carbon-furnace=__ITEM__advanced-carbon-furnace__
 
 [technology-description]
-enriched-tungsten=Enrich tungsten ore, purifying with ammonia [fluid=ammonia] and water [fluid=water], improving the final yield. Produce dirty water [fluid=dirty-water] as a byproduct.
+enriched-tungsten=狼重石をアンモニア[fluid=ammonia] と水で[fluid=water] 処理し、収量を改善します。副産物として汚水[fluid=dirty-water] を生産します。
 
 [recipe-name]
 enriched-tungsten=__ITEM__enriched-tungsten__
 tungsten-plate=__ITEM__tungsten-plate__
 smelt-compressed-tungsten-ore=__ITEM__tungsten-plate__
 tungsten-dust=__ITEM__tungsten-dust__
-dirty-water-filtration-tungsten=Filter dirty water [item=tungsten-ore]
+dirty-water-filtration-tungsten=汚水分離[item=tungsten-ore]
 
 [recipe-description]
-enriched-tungsten=Enrich tungsten ore, purifying with ammonia [fluid=ammonia] and water [fluid=water], improving the final yield. Produce dirty water [fluid=dirty-water] as a byproduct.
+enriched-tungsten=狼重石をアンモニア[fluid=ammonia] と水で[fluid=water] 処理し、収量を改善します。副産物として汚水[fluid=dirty-water] を生産します。
 
-dirty-water-filtration-tungsten=Filter dirty water, giving wolframite [item=tungsten-ore] and stone [item=stone] (probabilistically).
+dirty-water-filtration-tungsten=汚水をろ過し、狼重石[item=tungsten-ore] と石[item=stone] を確率的に生産します。
 
 # Settings
 
 [mod-setting-name]
-bztungsten-avoid-military=Avoid military science pack
-bztungsten-advanced-carbon-furnace=Enable the advanced carbon furnace
+bztungsten-avoid-military=軍事研究を不要にする
+bztungsten-advanced-carbon-furnace=強化炭素炉を有効にする
 
 [mod-setting-description]
-bztungsten-avoid-military=If 'yes', rocketry will no longer require military science.
-bztungsten-advanced-carbon-furnace=A furnace to smelt tungsten carbide quickly. Meant only for very large factories.
+bztungsten-avoid-military=「はい」の場合、ロケット工学に軍事研究が不要となります。
+bztungsten-advanced-carbon-furnace=炭化タングステンを高速精錬する炉。極めて大規模な工場向け。


### PR DESCRIPTION
Will rebase if upstream is updated.

Wolframite is typically translated to 鉄マンガン重石 (iron-manganese-heavy-stone(=Tungsten)) but I adopted old and minor 狼重石 (wolf-heavy-stone) to respect @brevven's intention. There are some old (1950s) Japanese journal articles mentioning 狼重石: [1](https://www.jstage.jst.go.jp/article/shigentosozai1953/72/822/72_822_927/_pdf/-char/ja), [2](https://www.jstage.jst.go.jp/article/shigentosozai1953/79/901/79_901_499/_pdf/-char/ja).
