### PR TITLE
fixed german locale

### DIFF
--- a/locale/de/tungsten.cfg
+++ b/locale/de/tungsten.cfg
@@ -1,17 +1,5 @@
-[entity-name]
-tungsten-ore=__ITEM__tungsten-ore__
-tungsten-chest=__ITEM__tungsten-chest__
-advanced-carbon-furnace=__ITEM__advanced-carbon-furnace__
-
-[entity-description]
-advanced-carbon-furnace=Schnelle und effiziente __ITEM__tungsten-carbide__ Herstellung. Verbraucht eine Menge Brennstoff.
-
-
-[autoplace-control-names]
-tungsten-ore=[item=tungsten-ore] __ITEM__tungsten-ore__
-
 [item-name]
-tungsten = Wolfram
+tungsten=Wolfram
 tungsten-ore=__ITEM__tungsten__it
 tungsten-dust=__ITEM__tungsten__ Pulver
 tungsten-plate=__ITEM__tungsten__ Platte
@@ -26,6 +14,17 @@ advanced-carbon-furnace=Fortschrittlicher Kohlenstoffofen
 tungsten-ore=Kann zu __ITEM__tungsten-plate__n geschmolzen werden.
 enriched-tungsten=Kann effizient zu __ITEM__tungsten-plate__n geschmolzen werden.
 advanced-carbon-furnace=Schnelle und effiziente __ITEM__tungsten-carbide__ Herstellung. Verbraucht eine Menge Brennstoff.
+
+[entity-name]
+tungsten-ore=__ITEM__tungsten-ore__
+tungsten-chest=__ITEM__tungsten-chest__
+advanced-carbon-furnace=__ITEM__advanced-carbon-furnace__
+
+[entity-description]
+advanced-carbon-furnace=Schnelle und effiziente __ITEM__tungsten-carbide__ Herstellung. Verbraucht eine Menge Brennstoff.
+
+[autoplace-control-names]
+tungsten-ore=[item=tungsten-ore] __ITEM__tungsten-ore__
 
 [technology-name]
 tungsten-processing=__ITEM__tungsten__ Verarbeitung
@@ -46,10 +45,8 @@ dirty-water-filtration-tungsten=Filtere verunreinigtes Wasser [item=tungsten-ore
 
 [recipe-description]
 enriched-tungsten=Reichere __ITEM__tungsten-ore__ an, veredele es mit Ammoniak [fluid=ammonia] und Wasser [fluid=water] und erhöhe die Reichhaltigkeit.\n Erzeugt verunreinigtes Wasser [fluid=dirty-water] als Nebenprodukt.
-
 dirty-water-filtration-tungsten=Filtere verunreinigtes Wasser um __ITEM__tungsten-ore__ [item=tungsten-ore] und __ITEM__stone__ [item=stone] (wahrscheinlich) zu erhalten.
 
-# Settings
 [mod-setting-name]
 bztungsten-recipe-bypass=Umgehe Rezepte
 bztungsten-avoid-military=Ignoriere militärische Wissenschaftspakete
@@ -59,3 +56,4 @@ bztungsten-advanced-carbon-furnace=Nutze den __ITEM__advanced-carbon-furnace__
 bztungsten-recipe-bypass=Ignoriere diese Rezepte (Komma-getrennte Liste).
 bztungsten-avoid-military=Wenn 'ja' wird die Rakete keine militärischen Wissenschaftspakete benötigen.
 bztungsten-advanced-carbon-furnace=Ein Ofen um __ITEM__tungsten-carbide__ schnell zu schmelzen. Für große Fabriken gedacht.
+


### PR DESCRIPTION
mistakes where made
I had a space between 'tungsten' and '=' so item name tungsten couldn't be found. It's fixed now an ill add the new tech name when the patch is out