### PR TITLE
Change translation wording to match with K2

### DIFF
--- a/locale/ja/tungsten.cfg
+++ b/locale/ja/tungsten.cfg
@@ -41,7 +41,7 @@ enriched-tungsten=__ITEM__enriched-tungsten__
 tungsten-plate=__ITEM__tungsten-plate__
 smelt-compressed-tungsten-ore=__ITEM__tungsten-plate__
 tungsten-dust=__ITEM__tungsten-dust__
-dirty-water-filtration-tungsten=汚水分離[item=tungsten-ore]
+dirty-water-filtration-tungsten=汚水をろ過[item=tungsten-ore]
 
 [recipe-description]
 enriched-tungsten=狼重石をアンモニア[fluid=ammonia] と水で[fluid=water] 処理し、収量を改善します。副産物として汚水[fluid=dirty-water] を生産します。


### PR DESCRIPTION
This PR updates ja translation of dirty-water-filtration-tungsten to match with K2's existing recipes.
