### PR TITLE
update ja 202305

### DIFF
--- a/locale/ja/tungsten.cfg
+++ b/locale/ja/tungsten.cfg
@@ -12,7 +12,8 @@ tungsten-ore=[item=tungsten-ore] 狼重石
 
 [item-name]
 tungsten-ore=狼重石
-tungsten-dust=狼重石の粉末
+tungsten-powder=タングステン粉末
+tungsten-dust=Tungsten dust
 tungsten-plate=タングステン板
 tungsten-carbide=炭化タングステン
 rocket-engine-nozzle=ロケットエンジンノズル
@@ -60,7 +61,7 @@ bztungsten-mining-fluid-amount=掘削に使用する流体の必要量
 bztungsten-mining-fluid-amount-k2=掘削に使用する流体の必要量(Krastorio 2)
 bztungsten-starting-patch=スタートエリアに狼重石鉱床
 bztungsten-more-intermediates=中間生産物を追加
-bztungsten-se-sintering=SE:鋳造の代わりに粉末タングステンを焼結
+bztungsten-se-sintering=SE:鋳造の代わりにタングステン粉末を焼結
 
 [mod-setting-description]
 bztungsten-recipe-bypass=指定したレシピの改変を行わない (コンマ区切り)。
@@ -69,7 +70,7 @@ bztungsten-advanced-carbon-furnace=炭化タングステンを高速精錬する
 bztungsten-mining-fluid-amount=掘削に使用する流体 (水) の必要量。デフォルト: 10。註: ゲーム内ではこの値の十分の一の数値として表示される箇所があります。
 bztungsten-mining-fluid-amount-k2=Krastorio 2で掘削に使用する流体の必要量。デフォルト: 1。註: ゲーム内ではこの値の十分の一の数値として表示される箇所があります。
 bztungsten-starting-patch=新たなゲームでスタートエリアに狼重石鉱床あり。バニラ・AAIなどではデフォルトで無効。
-bztungsten-se-sintering=タングステンは融点が高いため、融解タングステンから鋳造する代わりに粉末タングステンを焼結します。
+bztungsten-se-sintering=タングステンは融点が高いため、溶融タングステンから鋳造する代わりにタングステン粉末を焼結します。
 
 [string-mod-setting]
 bztungsten-more-intermediates-no=いいえ

--- a/locale/ja/tungsten.cfg
+++ b/locale/ja/tungsten.cfg
@@ -15,6 +15,7 @@ tungsten-ore=狼重石
 tungsten-powder=タングステン粉末
 tungsten-dust=Tungsten dust
 tungsten-plate=タングステン板
+tungsten-ingot=タングステンインゴット
 tungsten-carbide=炭化タングステン
 rocket-engine-nozzle=ロケットエンジンノズル
 enriched-tungsten=純化タングステン
@@ -28,6 +29,9 @@ tungsten-ore=製錬してタングステン板を得ることができます
 enriched-tungsten=製錬して効率的にタングステン板を得ることができます
 advanced-carbon-furnace=高速かつ効率的に炭化タングステンを生成できます。燃料を大量に消費します。
 cuw=銅タングステン複合材
+
+[fluid-name]
+molten-tungsten=溶融タングステン
 
 [technology-name]
 tungsten-processing=タングステン処理
@@ -59,6 +63,7 @@ bztungsten-avoid-military=軍事研究を不要にする
 bztungsten-advanced-carbon-furnace=強化炭素炉を有効にする
 bztungsten-mining-fluid-amount=掘削に使用する流体の必要量
 bztungsten-mining-fluid-amount-k2=掘削に使用する流体の必要量(Krastorio 2)
+bztungsten-mining-fluid-k2=掘削に使用する流体(Krastorio 2)
 bztungsten-starting-patch=スタートエリアに狼重石鉱床
 bztungsten-more-intermediates=中間生産物を追加
 bztungsten-se-sintering=SE:鋳造の代わりにタングステン粉末を焼結
@@ -75,3 +80,9 @@ bztungsten-se-sintering=タングステンは融点が高いため、溶融タ�
 [string-mod-setting]
 bztungsten-more-intermediates-no=いいえ
 bztungsten-more-intermediates-cuw=はい: __ITEM__cuw__
+bztungsten-avoid-military-yes=はい
+bztungsten-avoid-military-no=いいえ
+bztungsten-advanced-carbon-furnace-yes=はい
+bztungsten-advanced-carbon-furnace-no=いいえ
+bztungsten-mining-fluid-k2-mineral-water=__FLUID__mineral-water__
+bztungsten-mining-fluid-k2-water=__FLUID__water__

--- a/locale/ja/tungsten.cfg
+++ b/locale/ja/tungsten.cfg
@@ -24,8 +24,8 @@ advanced-carbon-furnace=強化炭素炉
 cuw=銅タングステン
 
 [item-description]
-tungsten-ore=精錬してタングステン板を得ることができます
-enriched-tungsten=精錬して効率的にタングステン板を得ることができます
+tungsten-ore=製錬してタングステン板を得ることができます
+enriched-tungsten=製錬して効率的にタングステン板を得ることができます
 advanced-carbon-furnace=高速かつ効率的に炭化タングステンを生成できます。燃料を大量に消費します。
 cuw=銅タングステン複合材
 


### PR DESCRIPTION
- Untranslate dust but translate powder as "粉末"
  both will be translated as "粉末" but I choose leaving dust untranslated (is it used in only untranslated MOD(5dim)?) and adopt the word for powder (for SE?)

- Fix wording
- Add more translations
