### PR TITLE
Fixing bobplates / aai-industry compatibility

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -55,5 +55,6 @@ util.remove_ingredient("rail-chain-signal-scrap", "small-lamp")
 
 
 if mods["aai-industry"] and mods.bobplates then
-  util.remove_prerequisite("tungsten-processing", "chemical-science-pack")
+  util.remove_prerequisite("oil-processing", "tungsten-processing")
+  util.add_prerequisite("oil-processing", "bz-tungsten-processing")
 end


### PR DESCRIPTION
Mod list:
- aai-industry
- bobplates
- bztungsten

Although it loads, the game is still soft locked. Chemical science pack has a a prerequisite tech (Tungsten processing) which requires Chemical science packs. Oil processing should instead depend on Basic tungsten processing.

![image](https://github.com/brevven/tungsten/assets/59639/f8c56713-2337-4748-afdc-98bd31f3a6de)

https://mods.factorio.com/mod/bztungsten/discussion/6399e29c8dfa545cf12a0802
